### PR TITLE
Add sub-schema tabs to the HDF SchemaViewer

### DIFF
--- a/docs/.vitepress/theme/components/SchemaViewer.spec.ts
+++ b/docs/.vitepress/theme/components/SchemaViewer.spec.ts
@@ -1,0 +1,106 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import { defineComponent, h } from 'vue'
+import SchemaViewer from './SchemaViewer.vue'
+
+// vue3-json-viewer is browser-only and dynamically imported by the component.
+// Stub it with a component that serialises the `value` it receives, so tests
+// can assert *which* (sub)schema node is being displayed.
+vi.mock('vue3-json-viewer', () => ({
+  JsonViewer: defineComponent({
+    name: 'JsonViewerStub',
+    props: { value: { type: null, default: null } },
+    setup: props => () => h('pre', { 'data-testid': 'json' }, JSON.stringify(props.value)),
+  }),
+}))
+
+const SCHEMA = {
+  type: 'object',
+  title: 'Exec JSON',
+  properties: {
+    platform: { $ref: '#/definitions/Platform' },
+    statistics: { $ref: '#/definitions/Statistics' },
+  },
+  definitions: {
+    Platform: { type: 'object', title: 'Platform schema', properties: { name: { type: 'string' } } },
+    Statistics: { type: 'object', title: 'Statistics schema' },
+  },
+}
+
+const TABS = [
+  { label: 'Full Schema', pointer: '' },
+  { label: 'Platform', pointer: 'definitions/Platform' },
+  { label: 'Statistics', pointer: 'definitions/Statistics' },
+]
+
+function stubFetch() {
+  vi.stubGlobal('fetch', vi.fn(async () => ({
+    ok: true,
+    json: async () => SCHEMA,
+  })))
+}
+
+async function mountReady(props: Record<string, unknown>) {
+  stubFetch()
+  const wrapper = mount(SchemaViewer, { props: { src: '/schema.json', ...props } })
+  // onMounted does a dynamic import (needs a macrotask, so flushPromises alone
+  // isn't enough) then fetches + parses the schema. Wait for loading to clear.
+  await vi.waitFor(() => expect(wrapper.find('.schema-viewer-loading').exists()).toBe(false))
+  return wrapper
+}
+
+describe('schemaViewer with tabs', () => {
+  it('renders an accessible tablist with one tab per entry', async () => {
+    const wrapper = await mountReady({ tabs: TABS })
+
+    const tablist = wrapper.find('[role="tablist"]')
+    expect(tablist.exists()).toBe(true)
+
+    const tabs = wrapper.findAll('[role="tab"]')
+    expect(tabs).toHaveLength(TABS.length)
+    expect(tabs.map(t => t.text())).toEqual(['Full Schema', 'Platform', 'Statistics'])
+  })
+
+  it('shows the whole document on the first (Full Schema) tab', async () => {
+    const wrapper = await mountReady({ tabs: TABS })
+
+    const json = wrapper.get('[data-testid="json"]').text()
+    expect(json).toContain('Exec JSON')
+    expect(json).toContain('definitions')
+  })
+
+  it('switches the displayed node when another tab is selected', async () => {
+    const wrapper = await mountReady({ tabs: TABS })
+
+    const platformTab = wrapper.findAll('[role="tab"]').find(t => t.text() === 'Platform')!
+    // Reka's tabs use automatic activation — selection follows focus.
+    await platformTab.trigger('focus')
+    await platformTab.trigger('click')
+
+    // Reka mounts only the active panel's content, so once it swaps the visible
+    // viewer shows just the Platform sub-schema, not the full root document.
+    await vi.waitFor(() => {
+      const json = wrapper.get('[data-testid="json"]').text()
+      expect(json).toContain('Platform schema')
+      expect(json).not.toContain('definitions')
+    })
+  })
+
+  it('falls back to the full document with no tab bar when tabs are omitted', async () => {
+    const wrapper = await mountReady({})
+
+    expect(wrapper.find('[role="tablist"]').exists()).toBe(false)
+    const json = wrapper.get('[data-testid="json"]').text()
+    expect(json).toContain('Exec JSON')
+    expect(json).toContain('definitions')
+  })
+
+  it('surfaces a fetch failure as an error message', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false, status: 404 })))
+    const wrapper = mount(SchemaViewer, { props: { src: '/missing.json', tabs: TABS } })
+
+    await vi.waitFor(() => expect(wrapper.find('.schema-viewer-error').exists()).toBe(true))
+    expect(wrapper.find('.schema-viewer-error').text()).toContain('404')
+    expect(wrapper.find('[role="tablist"]').exists()).toBe(false)
+  })
+})

--- a/docs/.vitepress/theme/components/SchemaViewer.vue
+++ b/docs/.vitepress/theme/components/SchemaViewer.vue
@@ -1,13 +1,36 @@
 <script setup lang="ts">
 import type { Component } from 'vue'
+import { TabsContent, TabsList, TabsRoot, TabsTrigger } from 'reka-ui'
 import { useData } from 'vitepress'
-import { onMounted, ref, shallowRef } from 'vue'
+import { computed, onMounted, ref, shallowRef } from 'vue'
+
+/**
+ * A single sub-schema tab.
+ */
+export interface SchemaTab {
+  /** Label shown on the tab button. */
+  label: string
+  /**
+   * JSON-pointer-style path into the loaded document, slash-separated
+   * (e.g. `'definitions/Platform'`). An empty string targets the whole
+   * document — use it for a "Full Schema" tab.
+   */
+  pointer: string
+}
 
 const props = withDefaults(defineProps<{
   /** URL path to the JSON file to display */
   src: string
   /** Initial expansion depth */
   expandDepth?: number
+  /**
+   * Optional sub-schema tabs. When provided, a tab bar is rendered above the
+   * viewer so users can jump straight to a referenced sub-schema/primitive
+   * (the targets of the schema's `$ref`s) instead of hunting for it inside the
+   * full document. Without this prop the viewer shows the whole document, as
+   * before.
+   */
+  tabs?: SchemaTab[]
 }>(), {
   expandDepth: 2,
 })
@@ -18,6 +41,25 @@ const jsonData = ref<Record<string, unknown> | null>(null)
 const loading = ref(true)
 const error = ref<string | null>(null)
 const ViewerComponent = shallowRef<Component | null>(null)
+
+const activeTab = ref(props.tabs?.[0]?.pointer ?? '')
+
+/**
+ * Resolve a slash-separated JSON pointer against the loaded document.
+ * An empty pointer returns the whole document. Returns `undefined` if any
+ * segment is missing, so the viewer can show nothing rather than throw.
+ */
+function resolvePointer(pointer: string): unknown {
+  if (!jsonData.value || pointer === '')
+    return jsonData.value
+  return pointer.split('/').reduce<unknown>((node, key) => {
+    if (node && typeof node === 'object')
+      return (node as Record<string, unknown>)[key]
+    return undefined
+  }, jsonData.value)
+}
+
+const theme = computed(() => (isDark.value ? 'dark' : 'light'))
 
 onMounted(async () => {
   try {
@@ -47,15 +89,44 @@ onMounted(async () => {
     <div v-else-if="error" class="schema-viewer-error">
       {{ error }}
     </div>
+
+    <!-- Tabbed view: one tab per referenced sub-schema. -->
+    <TabsRoot v-else-if="tabs?.length && jsonData && ViewerComponent" v-model="activeTab" class="schema-tabs">
+      <TabsList class="schema-tablist" aria-label="HDF schema sections">
+        <TabsTrigger
+          v-for="tab in tabs"
+          :key="tab.pointer"
+          :value="tab.pointer"
+          class="schema-tab"
+        >
+          {{ tab.label }}
+        </TabsTrigger>
+      </TabsList>
+      <TabsContent
+        v-for="tab in tabs"
+        :key="tab.pointer"
+        :value="tab.pointer"
+        class="schema-tabpanel"
+      >
+        <component
+          :is="ViewerComponent"
+          :value="resolvePointer(tab.pointer)"
+          :expand-depth="expandDepth"
+          :theme="theme"
+          copyable
+          sort
+        />
+      </TabsContent>
+    </TabsRoot>
+
+    <!-- Default: whole document, no tabs. -->
     <component
       :is="ViewerComponent"
       v-else-if="jsonData && ViewerComponent"
       :value="jsonData"
       :expand-depth="expandDepth"
-      :theme="isDark ? 'dark' : 'light'"
+      :theme="theme"
       copyable
-      boxed
-      expanded
       sort
     />
   </div>
@@ -81,10 +152,54 @@ onMounted(async () => {
   color: var(--vp-c-danger-1, #e53e3e);
 }
 
-/* Override vue3-json-viewer defaults for VitePress compatibility */
+.schema-tablist {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  border-bottom: 1px solid var(--vp-c-divider);
+  margin-bottom: 0.75rem;
+}
+
+.schema-tab {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  border-bottom: 2px solid transparent;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.875rem;
+  line-height: 1.4;
+  color: var(--vp-c-text-2);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: color 0.1s, border-color 0.1s;
+}
+
+.schema-tab:hover {
+  color: var(--vp-c-text-1);
+}
+
+.schema-tab[data-state='active'] {
+  color: var(--vp-c-brand-1);
+  border-bottom-color: var(--vp-c-brand-1);
+  font-weight: 600;
+}
+
+/* Keyboard focus must be clearly visible (WCAG 2.4.7). */
+.schema-tab:focus-visible {
+  outline: 2px solid var(--vp-c-brand-1);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+/* Override vue3-json-viewer defaults for VitePress compatibility.
+   We intentionally do NOT use the viewer's own `boxed` mode: it clamps the
+   code to 300px and adds a "show more" gradient/chevron (.jv-more) that stays
+   pinned to the bottom even once expanded. Instead we box and scroll the
+   schema ourselves here. */
 .jv-container {
   font-family: var(--vp-font-family-mono) !important;
   font-size: 13px !important;
+  border: 1px solid var(--vp-c-divider);
   border-radius: 8px !important;
   max-height: 900px;
   overflow: auto;

--- a/docs/resources/schema.md
+++ b/docs/resources/schema.md
@@ -13,9 +13,21 @@ The MITRE Heimdall™ Data Format (HDF) schema defines the structure for securit
 
 ## Interactive Schema
 
-Expand and collapse sections to explore the full [HDF JSON Schema](https://github.com/mitre/heimdall2/blob/master/libs/inspecjs/schemas/exec-json.json).
+Expand and collapse sections to explore the full [HDF JSON Schema](https://github.com/mitre/heimdall2/blob/master/libs/inspecjs/schemas/exec-json.json). Use the tabs to jump straight to a referenced sub-schema — these mirror the field tables below.
 
-<SchemaViewer src="/exec-json-schema.json" :expand-depth="3" />
+<SchemaViewer
+  src="/exec-json-schema.json"
+  :expand-depth="3"
+  :tabs="[
+    { label: 'Full Schema', pointer: '' },
+    { label: 'Platform', pointer: 'definitions/Platform' },
+    { label: 'Profile', pointer: 'definitions/Exec_JSON_Profile' },
+    { label: 'Control', pointer: 'definitions/Exec_JSON_Control' },
+    { label: 'Result', pointer: 'definitions/Control_Result' },
+    { label: 'Statistics', pointer: 'definitions/Statistics' },
+    { label: 'Attestation', pointer: 'definitions/Attestation_Data' },
+  ]"
+/>
 
 ## Root Object
 


### PR DESCRIPTION
Resolves saf-site-vitepress-90s. The interactive viewer on /resources/schema only showed the full document, with referenced sub-schemas (platform, profiles, statistics, version, ...) appearing as bare $ref strings. Add an optional `tabs` prop that renders an accessible Reka tab bar; each tab resolves a JSON-pointer path and shows that sub-schema directly, giving parity with the field tables below. Without the prop the viewer behaves exactly as before.

Wire up tabs on the schema page mirroring the existing table sections (Full Schema, Platform, Profile, Control, Result, Statistics, Attestation).

Also drop the viewer's `boxed`/`expanded` mode: it clamped the code to 300px and left a "show more" gradient bar (.jv-more) pinned to the bottom even once expanded. We box and scroll the schema ourselves, so the artifact is gone.